### PR TITLE
Incorrect plugin configuration example in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ config/plugins.js
 ```
 module.exports = {
     // ...
-    'strapi-date-range-picker-plugin': {
+    'date-range-picker': {
       enabled: true
     },
     // ...


### PR DESCRIPTION
The documentation currently provides the following example plugin configuration: 
```ts
module.exports = {
    // ...
    'strapi-date-range-picker-plugin': {
      enabled: true
    },
    // ...
  }
```
but using this configuration produces the error: 
```
Error: Error loading the plugin strapi-date-range-picker-plugin because strapi-date-range-picker-plugin is not installed. Please either install the plugin or remove it's configuration.
```

This is because the name of the plugin, as far as Strapi is concerned, is actually "date-range-picker".

I updated the documentation to reflect this:
```ts
module.exports = {
    // ...
    'date-range-picker': {
      enabled: true
    },
    // ...
  }
```